### PR TITLE
Add `auto` as a new dark mode strategy

### DIFF
--- a/packages/hashi/_init-base.scss
+++ b/packages/hashi/_init-base.scss
@@ -31,7 +31,7 @@
 
 @use 'init-font-pack' as font-pack;
 
-$_valid-dark-modes: ('attribute', 'media', 'class');
+$_valid-dark-modes: ('attribute', 'media', 'class', 'auto');
 
 $primary: 'dp-black' !default;
 $primary-dark: 'dp-white' !default;
@@ -131,6 +131,18 @@ $_tones: (
   @if $_dark-mode == 'class' {
     @at-root #{selector.nest('html.is-dark', &)} {
       @content;
+    }
+  }
+
+  @if $_dark-mode == 'auto' {
+    @at-root #{selector.nest('html[hashi-theme="dark"], html[data-theme="dark"], html[theme="dark"], html.is-dark', &)} {
+      @content;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      @at-root #{selector.nest('html:not([hashi-theme="light"]), html:not([data-theme="light"]), html:not([theme="light"]), html:not(.is-light)', &)} {
+        @content;
+      }
     }
   }
 }

--- a/packages/hashi/package.json
+++ b/packages/hashi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devprotocol/hashi",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Dev Protocol's design system implementation for the web.",
   "main": "./_index.scss",
   "exports": {


### PR DESCRIPTION
Added "auto" as a dark mode strategy. "auto" behaves like the following:
- **Explicit dark mode by attribute** - If `<html>` has one of the following attributes, hashi takes dark mode: `hashi-theme="dark"`, `data-theme="dark"`, `theme="dark"`
- **Explicit dark mode by class** - If `<html>` has `is-dark` class, hashi takes dark mode.
- **Automatically dark mode by media query** - If media query `prefers-color-scheme` is dark, hashi takes dark mode.
- **Cancel dark mode by attribute/class** - If media query `prefers-color-scheme` is dark and `<html>` has `is-light` class or one of the following attributes, hashi doesn't use dark mode: `hashi-theme="light"`, `data-theme="light"`, `theme="light"`

This allows Clubs themes and some pages to explicitly disallow dark mode while enabling dark mode by default.
